### PR TITLE
fix(deploy): Change Docker port to 8001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend/app ./app
 
 # Expose the port the app runs on
-EXPOSE 8000
+EXPOSE 8001
 
 # Define the command to run the app
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]


### PR DESCRIPTION
This commit updates the `Dockerfile` to expose and run the backend application on port 8001. This change was made to avoid a port conflict on the deployment server where port 8000 is already in use.