### PR TITLE
fix(backend): Add python-multipart dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic-settings==2.11.0
 supabase==2.21.1
 python-jose==3.5.0
 passlib[bcrypt]==1.7.4
+python-multipart


### PR DESCRIPTION
This commit adds `python-multipart` to the `requirements.txt` file.

The backend application was crashing on startup because this dependency, which is required by FastAPI to handle form data, was missing. Adding it to the requirements will ensure it's installed in the Docker container, allowing the application to start and run correctly.