### PR TITLE
Hotfix: Hardcode frontend API URL and key to resolve environment issues

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: 'https://ghars-api.hasmah.xyz/api/v1',
   headers: {
-    'X-API-KEY': import.meta.env.VITE_API_KEY,
+    'X-API-KEY': 'a_very_secret_api_key',
   },
 });
 


### PR DESCRIPTION
This commit hardcodes the backend API URL and API key directly into the frontend's API service. This is a temporary measure to ensure the application functions correctly in environments where the `.env` file may not be properly configured, resolving the "405 Method Not Allowed" error.

This hotfix builds upon the previous changes:
- Corrected `package-lock.json` location.
- Secured backend secrets by moving them to a `.env` file.
- Implemented API key authentication for all backend endpoints.
- Adjusted student access to allow students to view their own data.
- Set a default administrator password.
- Secured the login endpoint with the API key.
- Resolved a merge conflict by reverting a hardcoded URL.