### PR TITLE
Refactor: Remove API key system entirely

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,6 +1,6 @@
 from typing import Any, Generator
-from fastapi import Depends, HTTPException, status, Security
-from fastapi.security import OAuth2PasswordBearer, APIKeyHeader
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
 from jose import jwt
 from pydantic import ValidationError
 from supabase import Client
@@ -9,16 +9,6 @@ from app.core import security
 from app.core.config import settings
 from app.db.supabase import get_supabase_client
 from app.schemas.token import TokenData
-
-api_key_header = APIKeyHeader(name="X-API-KEY", auto_error=False)
-
-def get_api_key(api_key_header: str = Security(api_key_header)):
-    if api_key_header == settings.API_KEY:
-        return api_key_header
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Could not validate API KEY"
-        )
 
 reusable_oauth2 = OAuth2PasswordBearer(
     tokenUrl=f"{settings.API_V1_STR}/token"

--- a/backend/app/api/endpoints/login.py
+++ b/backend/app/api/endpoints/login.py
@@ -6,15 +6,13 @@ from app.services.user_service import UserService
 from app.schemas.token import Token
 from app.core.security import create_access_token
 from app.db.supabase import get_supabase_client
-from app.api import deps
 
 router = APIRouter()
 
 @router.post("/token", response_model=Token)
 def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
-    db: Any = Depends(get_supabase_client),
-    api_key: str = Depends(deps.get_api_key)
+    db: Any = Depends(get_supabase_client)
 ) -> Any:
     """
     OAuth2 compatible token login, gets an access token for future requests

--- a/backend/app/api/endpoints/students.py
+++ b/backend/app/api/endpoints/students.py
@@ -13,8 +13,7 @@ def create_student(
     *,
     db: Client = Depends(deps.get_supabase_client),
     student_in: UserCreate,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Create new student.
@@ -31,8 +30,7 @@ def create_student(
 @router.get("/", response_model=List[User])
 def read_students(
     db: Client = Depends(deps.get_supabase_client),
-    current_user: Any = Depends(deps.get_current_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_user)
 ) -> Any:
     """
     Retrieve all students.
@@ -53,8 +51,7 @@ def update_student(
     db: Client = Depends(deps.get_supabase_client),
     student_id: int,
     student_in: UserUpdate,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Update a student's points, name, or class.
@@ -74,8 +71,7 @@ def delete_student(
     *,
     db: Client = Depends(deps.get_supabase_client),
     student_id: int,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Delete a student.

--- a/backend/app/api/endpoints/weeks.py
+++ b/backend/app/api/endpoints/weeks.py
@@ -16,8 +16,7 @@ def create_week(
     *,
     db: Client = Depends(deps.get_supabase_client),
     week_in: WeekCreate,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Create a new week.
@@ -28,8 +27,7 @@ def create_week(
 
 @router.get("/", response_model=List[Week])
 def read_weeks(
-    db: Client = Depends(deps.get_supabase_client),
-    api_key: str = Depends(deps.get_api_key)
+    db: Client = Depends(deps.get_supabase_client)
 ) -> Any:
     """
     Retrieve all weeks with their content.
@@ -41,8 +39,7 @@ def read_weeks(
 def read_week(
     *,
     db: Client = Depends(deps.get_supabase_client),
-    week_id: int,
-    api_key: str = Depends(deps.get_api_key)
+    week_id: int
 ) -> Any:
     """
     Get a specific week by ID, if it's not locked.
@@ -63,8 +60,7 @@ def update_week(
     db: Client = Depends(deps.get_supabase_client),
     week_id: int,
     week_in: WeekUpdate,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Update a week's details (title, lock status).
@@ -81,8 +77,7 @@ def upload_week_video(
     db: Client = Depends(deps.get_supabase_client),
     week_id: int,
     file: UploadFile = File(...),
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ):
     """
     Upload a video for a week.
@@ -102,8 +97,7 @@ def create_content_card(
     db: Client = Depends(deps.get_supabase_client),
     week_id: int,
     card_in: ContentCardCreate,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Add a new content card to a week.
@@ -121,8 +115,7 @@ def update_content_card(
     db: Client = Depends(deps.get_supabase_client),
     card_id: int,
     card_in: ContentCardUpdate,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Update a content card.
@@ -139,8 +132,7 @@ def delete_content_card(
     *,
     db: Client = Depends(deps.get_supabase_client),
     card_id: int,
-    current_user: Any = Depends(deps.get_current_admin_user),
-    api_key: str = Depends(deps.get_api_key)
+    current_user: Any = Depends(deps.get_current_admin_user)
 ) -> Any:
     """
     Delete a content card.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,7 +18,6 @@ class Settings(BaseSettings):
     SUPABASE_BUCKET: str = "videos"
 
     # Security settings
-    API_KEY: str
     SECRET_KEY: str
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8 # 8 days

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2,9 +2,6 @@ import axios from 'axios';
 
 const api = axios.create({
   baseURL: 'https://ghars-api.hasmah.xyz/api/v1',
-  headers: {
-    'X-API-KEY': 'a_very_secret_api_key',
-  },
 });
 
 // Function to set the authorization token on the api instance


### PR DESCRIPTION
This commit completely removes the API key authentication system from both the frontend and backend, simplifying the authorization model as requested by the user. Communication now relies on the hardcoded backend URL in the frontend.

This refactor includes:
- **Backend:** Removed all API key dependencies, configuration settings, and endpoint protections.
- **Frontend:** Removed the `X-API-KEY` header from all API requests and the corresponding environment variable.

This change supersedes and replaces the previous series of fixes related to API key implementation, environment variable loading, and merge conflicts. The application is now in a simplified state with a direct, hardcoded connection between the frontend and backend.