### PR TITLE
Fix TypeError in create_access_token function

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -10,16 +10,15 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 ALGORITHM = settings.ALGORITHM
 
-def create_access_token(
-    subject: Union[str, Any], expires_delta: timedelta = None
-) -> str:
+def create_access_token(data: dict, expires_delta: timedelta = None) -> str:
+    to_encode = data.copy()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
         expire = datetime.utcnow() + timedelta(
             minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
         )
-    to_encode = {"exp": expire, "sub": str(subject)}
+    to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 


### PR DESCRIPTION
The `create_access_token` function was expecting a `subject` argument, but it was being called with a `data` keyword argument from the login endpoint. This caused a `TypeError` during the login process.

This commit modifies the `create_access_token` function to accept a `data` dictionary directly. This allows it to handle arbitrary data, including the `sub` and `role` fields, making it more flexible and fixing the bug.