### PR TITLE
Fix: Correct Invalid CSS Class Causing Build Failure

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -14,7 +14,7 @@
 /* Base styles */
 @layer base {
   html, body, #root { height: 100%; }
-  body { @apply bg-black text-brand-white font-arabic antialiased; }
+  body { @apply bg-black text-brand-primary font-arabic antialiased; }
 }
 
 /* Utilities */


### PR DESCRIPTION
This commit resolves a build error caused by an incorrect class name in the main stylesheet (`frontend/src/styles/index.css`).

The class `text-brand-white` was being used, but it was removed from the Tailwind CSS configuration during a recent theme update. This commit replaces it with the correct class, `text-brand-primary`, which aligns with the new color palette.

This change allows the frontend application to build successfully.