### PR TITLE
Fix: Add missing useNavigate import to App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Routes, Route, Link, Navigate, useLocation } from 'react-router-dom';
+import { Routes, Route, Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { AuthContext } from './context/AuthContext';
 import Home from './pages/Home.jsx';
 import Weeks from './pages/Weeks.jsx';


### PR DESCRIPTION
This commit resolves a runtime error (`ReferenceError: useNavigate is not defined`) that occurred because the `useNavigate` hook was used in the `Navigation` component without being imported from `react-router-dom`.

The fix adds `useNavigate` to the import statement in `frontend/src/App.jsx`, allowing the application to render correctly without crashing.