### PR TITLE
fix: Add missing GET endpoint for admin weeks API

### DIFF
--- a/backend/app/api/endpoints/weeks.py
+++ b/backend/app/api/endpoints/weeks.py
@@ -12,6 +12,17 @@ public_router = APIRouter()
 
 # --- Admin Week Endpoints ---
 
+@admin_router.get("", response_model=List[Week])
+def read_weeks_admin(
+    db: Client = Depends(deps.get_supabase_client),
+    current_user: Any = Depends(deps.get_current_admin_user)
+) -> Any:
+    """
+    Retrieve all weeks with their content (Admin only).
+    """
+    week_service = WeekService(db)
+    return week_service.get_all_weeks_with_content()
+
 @admin_router.post("", response_model=Week, status_code=status.HTTP_201_CREATED)
 def create_week(
     *,


### PR DESCRIPTION
This commit resolves a `45 Method Not Allowed` error that occurred when trying to fetch the list of weeks from the admin panel.

A `GET` endpoint has been added to the `admin_router` in the weeks API to handle these requests.