### PR TITLE
fix: Resolve weeks page error and admin link visibility

### DIFF
--- a/frontend/src/pages/Weeks.jsx
+++ b/frontend/src/pages/Weeks.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
-import api, { setAuthToken } from '../services/api';
+import { setAuthToken, weekService } from '../services/api';
 import { AuthContext } from '../context/AuthContext';
 import Section from '../components/Section.jsx';
 
@@ -50,8 +50,8 @@ export default function Weeks() {
 
       try {
         setLoading(true);
-        const response = await api.get('/weeks');
-        setWeeks(response.data);
+        const data = await weekService.getAllWeeks();
+        setWeeks(data);
         setError('');
       } catch (err) {
         setError('Failed to fetch weeks.');

--- a/frontend/src/pages/admin/AdminLayout.jsx
+++ b/frontend/src/pages/admin/AdminLayout.jsx
@@ -15,19 +15,19 @@ const AdminLayout = () => {
       {/* Sidebar */}
       <aside className="w-64 flex-shrink-0 border-r border-gray-800 bg-gray-900 p-4">
         <div className="flex flex-col h-full">
-          <h2 className="text-xl font-semibold mb-6 px-2">Admin Panel</h2>
+          <h2 className="text-xl font-semibold mb-6 px-2">لوحة التحكم</h2>
           <nav className="flex flex-col space-y-2">
             <NavLink to="/admin/students" className={navLinkClasses}>
               <Users className="mr-3 h-5 w-5" />
-              Student Management
+              إدارة الطلاب
             </NavLink>
             <NavLink to="/admin/weeks" className={navLinkClasses}>
               <Video className="mr-3 h-5 w-5" />
-              Week Management
+              إدارة الأسابيع
             </NavLink>
             <NavLink to="/admin/classes" className={navLinkClasses}>
               <ClipboardList className="mr-3 h-5 w-5" />
-              Class Management
+              إدارة الفصول
             </NavLink>
           </nav>
         </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -28,4 +28,11 @@ export const classService = {
   },
 };
 
+export const weekService = {
+  getAllWeeks: async () => {
+    const response = await api.get('/weeks/'); // Added trailing slash
+    return response.data;
+  },
+};
+
 export default api;


### PR DESCRIPTION
This commit addresses the final two outstanding issues:

1.  **Weeks Page Fetch Error:**
    - Created a dedicated `weekService` in tthe frontend API to handle API calls to `/weeks/` with the correct trailing slash, resolving the redirect and the 'failed to fetch' error.
    - Updated the `Weeks.jsx` component to use this new service.

2.  **Admin Panel Links:**
    - Replaced the hardcoded English text in `AdminLayout.jsx` with the correct Arabic translations for all navigation links, including 'إدارة الفصول' (Class Management), ensuring it is visible and consistent with the rest of the UI.