### PR TITLE
Fix(frontend): Use flex-1 to ensure sticky footer behavior

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,7 +72,7 @@ const Layout = ({ children }) => {
   return (
     <div className="min-h-screen bg-black text-brand-primary flex flex-col font-arabic">
       <Navigation />
-      <main className="flex-grow">{children}</main>
+      <main className="flex-1">{children}</main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
The main layout was using `flex-grow` on the main content area, which did not reliably force the content to expand and fill the full height of the viewport on pages with little content. This caused the footer to "ride up" the page instead of sticking to the bottom.

This commit replaces `flex-grow` with `flex-1`. The `flex-1` utility is a more comprehensive shorthand that correctly sets the `flex-grow`, `flex-shrink`, and `flex-basis` properties, ensuring the main content area always takes up the maximum available space. This guarantees the footer will remain at the bottom of the screen across all pages, resolving the layout bug.